### PR TITLE
Vagrant 1.0 used instead of the newest version

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,15 +1,23 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-Vagrant::Config.run do |config|
+Vagrant.configure("2") do |config|
   config.vm.box = "varnishtraining"
   config.vm.box_url = "http://download.feryn.eu/varnishtraining.box"
-  config.vm.host_name = "varnishtraining"
-  config.vm.customize [
-        "modifyvm", :id,
-        "--name", "Varnish Training",
-        "--memory", "512"
-  ]
-  config.vm.network :hostonly, "10.10.10.6"
-  config.vm.share_folder "v-data", "/home/data", "./"
+  config.vm.hostname = "varnishtraining"
+
+  config.vm.network :private_network, ip: "10.10.10.6"
+
+  config.vm.provider :virtualbox do |v|
+    v.customize ["modifyvm", :id, '--chipset', 'ich9'] # solves kernel panic issue on some host machines
+    v.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
+    v.customize ["modifyvm", :id, "--memory", 512]
+    v.customize ["modifyvm", :id, "--ioapic", "on"]
+    #v.gui = true # turn gui on
+  end
+
+  #shared folders are slow even with nfs, warning nfs is not available on windows
+  #config.vm.synced_folder "./", "/home/data", nfs: true, id: "vagrant-root"
+  config.vm.synced_folder "./", "/home/data", id: "vagrant-root"
 end
+


### PR DESCRIPTION
Really helpfull hands on today with the varnish training, but couldn't help but notice you were still using the 1.0 syntax for Vagrant. So i updated it to a Vagrant 1.1 compatible version which is supported untill version 2.0 according to Vagrant's documentation.

Vagrant 1.0 is no longer supported but it is still backwards compatible but could break in the near future.
